### PR TITLE
feat: implement immediate seat locking during booking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Dependencies
+node_modules/
+
+# Firebase/Secrets
+serviceAccountKey.json
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS/Editor
+.DS_Store
+Thumbs.db
+.vscode/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "http-server public -p 8080 -o",
+    "serve": "http-server public -p 8080",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -11,5 +13,8 @@
   "description": "",
   "dependencies": {
     "firebase": "^12.0.0"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
   }
 }

--- a/public/js/firebase.js
+++ b/public/js/firebase.js
@@ -14,7 +14,8 @@ import {
   collection,
   onSnapshot,
   getDocs,
-  serverTimestamp
+  serverTimestamp,
+  runTransaction
 } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
 
 import {
@@ -54,6 +55,7 @@ export {
   onSnapshot,
   getDocs,
   serverTimestamp,
+  runTransaction,
   getAuth,
   onAuthStateChanged
 };

--- a/public/show-booking.html
+++ b/public/show-booking.html
@@ -37,13 +37,14 @@
   <footer><p>&copy; 2025 BookMyNIT. All rights reserved.</p></footer>
 
   <script type="module">
-    import { db, auth, doc, getDoc, setDoc, updateDoc, collection, getDocs, onAuthStateChanged, serverTimestamp } from "./js/firebase.js";
+    import { db, auth, doc, getDoc, setDoc, updateDoc, collection, getDocs, onAuthStateChanged, serverTimestamp, runTransaction } from "./js/firebase.js";
 
     const seatWrapper = document.getElementById("seatWrapper");
 const seatWrapperContainer = document.getElementById("seatWrapperContainer");
     const confirmBtn = document.getElementById("confirmBtn");
     let selectedSeats = [];
     let currentUser = null;
+    let seatTimers = {}; // Track timeout timers for each seat
 
     const seatLayout = [
       {
@@ -146,14 +147,18 @@ renderLayout();
           btn.dataset.priceKey = section.priceKey;
 
           const status = seatStatusMap[seatId];
+          const lockedByCurrentUser = seatStatusMap[seatId + '_by'] === currentUser?.uid;
 
-          if (status === 'locked') {
+          if (status === 'locked' && !lockedByCurrentUser) {
             btn.classList.add('locked');
             btn.disabled = true;
-            const lockedByCurrentUser = seatStatusMap[seatId + '_by'] === currentUser.uid;
-            btn.title = lockedByCurrentUser
-              ? "You have locked this seat."
-              : "This seat is temporarily locked by another user.";
+            btn.title = "This seat is temporarily locked by another user.";
+          } else if (status === 'locked' && lockedByCurrentUser) {
+            // Keep it interactive so user can deselect/unlock
+            btn.classList.add('selected');
+            btn.disabled = false;
+            btn.title = "You have locked this seat. Click to deselect.";
+            btn.addEventListener('click', () => toggleSeat(btn));
           } else if (status === 'booked') {
             btn.classList.add('booked');
             btn.disabled = true;
@@ -179,18 +184,103 @@ renderLayout();
 }
 
 
-    function toggleSeat(btn) {
+    async function toggleSeat(btn) {
   const seatId = btn.dataset.seat;
   const priceKey = btn.dataset.priceKey;
 
   if (btn.classList.contains("selected")) {
-    // Deselect locally
+    // Deselect locally and unlock in database
     btn.classList.remove("selected");
     selectedSeats = selectedSeats.filter(s => s.id !== seatId);
+    
+    // Clear the timeout timer for this seat
+    if (seatTimers[seatId]) {
+      clearTimeout(seatTimers[seatId]);
+      delete seatTimers[seatId];
+    }
+    
+    // Unlock the seat in database with safety check
+    try {
+      const seatRef = doc(db, "shows", "currentShow", "seats", seatId);
+      await runTransaction(db, async (tx) => {
+        const snap = await tx.get(seatRef);
+        if (!snap.exists()) return;
+        const data = snap.data();
+        if (data.status === 'locked' && data.lockedBy === currentUser.uid) {
+          tx.update(seatRef, {
+            status: "available",
+            lockedBy: null,
+            lockedAt: null
+          });
+        }
+      });
+    } catch (err) {
+      console.error("Failed to unlock seat:", err);
+    }
   } else {
-    // Select locally
+    const seatRef = doc(db, "shows", "currentShow", "seats", seatId);
+    // Select locally and attempt to lock in database atomically
     btn.classList.add("selected");
     selectedSeats.push({ id: seatId, priceKey });
+    
+    // Lock the seat immediately in database using transaction
+    try {
+      await runTransaction(db, async (tx) => {
+        const snap = await tx.get(seatRef);
+        if (snap.exists()) {
+          const data = snap.data();
+          if (data.status === 'available' || data.status === undefined) {
+            tx.update(seatRef, {
+              status: "locked",
+              lockedBy: currentUser.uid,
+              lockedAt: serverTimestamp()
+            });
+          } else {
+            throw new Error("Seat no longer available");
+          }
+        } else {
+          // In case documents are not pre-created
+          tx.set(seatRef, {
+            status: "locked",
+            lockedBy: currentUser.uid,
+            lockedAt: serverTimestamp()
+          });
+        }
+      });
+      
+      // Set a 10-minute timeout to auto-unlock the seat if not booked
+      seatTimers[seatId] = setTimeout(async () => {
+        try {
+          // Safely unlock via transaction if still locked by this user
+          await runTransaction(db, async (tx) => {
+            const s = await tx.get(seatRef);
+            if (s.exists()) {
+              const d = s.data();
+              if (d.status === 'locked' && d.lockedBy === currentUser.uid) {
+                tx.update(seatRef, {
+                  status: "available",
+                  lockedBy: null,
+                  lockedAt: null
+                });
+              }
+            }
+          });
+          // Remove from selected seats if still selected
+          selectedSeats = selectedSeats.filter(s => s.id !== seatId);
+          alert(`Seat ${seatId} has been automatically unlocked due to timeout. Please reselect if needed.`);
+        } catch (err) {
+          console.error("Failed to auto-unlock seat:", err);
+        }
+        delete seatTimers[seatId];
+      }, 10 * 60 * 1000); // 10 minutes
+      
+    } catch (err) {
+      console.error("Failed to lock seat:", err);
+      // If locking fails, remove from selection
+      btn.classList.remove("selected");
+      selectedSeats = selectedSeats.filter(s => s.id !== seatId);
+      alert("Failed to lock seat. Please try again.");
+    }
   }
 
   // Optional: update price/seat count UI
@@ -204,24 +294,42 @@ renderLayout();
     return;
   }
 
-  try {
-    for (const seat of selectedSeats) {
-      const seatRef = doc(db, "shows", "currentShow", "seats", seat.id);
-      await updateDoc(seatRef, {
-        status: "locked",
-        lockedBy: currentUser.uid,
-        lockedAt: serverTimestamp()
-      });
-    }
-
-    sessionStorage.setItem("selectedSeats", JSON.stringify(selectedSeats));
-    window.location.href = "payment.html";
-  } catch (err) {
-    alert("Failed to lock some seats. Please try again.");
-    console.error(err);
-  }
+  // Seats are already locked when selected, so just proceed to payment
+  sessionStorage.setItem("selectedSeats", JSON.stringify(selectedSeats));
+  
+  // Clear all timers since user is proceeding to payment
+  Object.values(seatTimers).forEach(timer => clearTimeout(timer));
+  seatTimers = {};
+  
+  window.location.href = "payment.html";
 });
 
+// Clean up locked seats when user leaves the page without booking
+window.addEventListener('beforeunload', async () => {
+  // Clear all timers
+  Object.values(seatTimers).forEach(timer => clearTimeout(timer));
+  
+  // Unlock all selected seats (safely)
+  for (const seat of selectedSeats) {
+    try {
+      const seatRef = doc(db, "shows", "currentShow", "seats", seat.id);
+      await runTransaction(db, async (tx) => {
+        const snap = await tx.get(seatRef);
+        if (!snap.exists()) return;
+        const data = snap.data();
+        if (data.status === 'locked' && data.lockedBy === currentUser?.uid) {
+          tx.update(seatRef, {
+            status: "available",
+            lockedBy: null,
+            lockedAt: null
+          });
+        }
+      });
+    } catch (err) {
+      console.error("Failed to unlock seat on page unload:", err);
+    }
+  }
+});
 
 });
 let isDown = false;


### PR DESCRIPTION
- Seats lock instantly when selected using Firestore transactions
- Auto-unlock after 10 minutes timeout
- Clean up locked seats on page unload/refresh
- Users can deselect their own locked seats
- Prevent race conditions with transactional updates
- Add runTransaction export to firebase.js
- Add npm scripts for local development
- Add .gitignore to exclude node_modules